### PR TITLE
Change Delayed::Settings to use Rails.env instead of RAILS_ENV and ENV['RAILS_ENV']

### DIFF
--- a/lib/delayed/settings.rb
+++ b/lib/delayed/settings.rb
@@ -84,7 +84,7 @@ module Delayed
     def self.worker_config(config_filename = nil)
       config_filename ||= default_worker_config_name
       config = YAML.load(ERB.new(File.read(config_filename)).result)
-      env = defined?(RAILS_ENV) ? RAILS_ENV : ENV['RAILS_ENV'] || 'development'
+      env = Rails.env || 'development'
       config = config[env] || config['default']
       # Backwards compatibility from when the config was just an array of queues
       config = { :workers => config } if config.is_a?(Array)


### PR DESCRIPTION
The `defined?(RAILS_ENV) ? RAILS_ENV : ...` check is no longer necessary, and it causes inst-jobs to interact badly with https://github.com/nakajima/acts_as_fu which (for some braindead reason) defines a global constant `RAILS_ENV = 'test'`.